### PR TITLE
009-[修正]DB修正：2FAとローカル認証の削除

### DIFF
--- a/backend/prisma/migrations/20260108131142_260108_first_fix/migration.sql
+++ b/backend/prisma/migrations/20260108131142_260108_first_fix/migration.sql
@@ -1,0 +1,104 @@
+/*
+  Warnings:
+
+  - You are about to drop the `AppStatus` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "AppStatus";
+PRAGMA foreign_keys=on;
+
+-- CreateTable
+CREATE TABLE "Statuses" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "category" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "Users" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "email" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "nickname" TEXT NOT NULL,
+    "pictureURL" TEXT,
+    "statusId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "Tournaments" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "statusId" INTEGER NOT NULL,
+    "winnerId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "WaitingRooms" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "statusId" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "adminUserId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "WaitingRoomParticipants" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "statusId" INTEGER NOT NULL,
+    "waitingRoomId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "Games" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "statusId" INTEGER NOT NULL,
+    "tournamentId" INTEGER NOT NULL,
+    "round" INTEGER NOT NULL DEFAULT 1,
+    "order" INTEGER NOT NULL DEFAULT 1,
+    "playerNum" INTEGER NOT NULL DEFAULT 2,
+    "gameTypeId" INTEGER NOT NULL,
+    "winnerId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "GameTypes" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "statusId" INTEGER NOT NULL,
+    "gameType" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "PlayerScores" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "statusId" INTEGER NOT NULL,
+    "gameId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Statuses_category_name_key" ON "Statuses"("category", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Users_email_key" ON "Users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WaitingRoomParticipants_waitingRoomId_userId_key" ON "WaitingRoomParticipants"("waitingRoomId", "userId");

--- a/backend/prisma/migrations/20260115060902_260115_second_fix/migration.sql
+++ b/backend/prisma/migrations/20260115060902_260115_second_fix/migration.sql
@@ -1,0 +1,41 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `WaitingRooms` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Games" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "statusId" INTEGER NOT NULL,
+    "tournamentId" INTEGER NOT NULL,
+    "round" INTEGER NOT NULL,
+    "order" INTEGER NOT NULL,
+    "playerNum" INTEGER NOT NULL,
+    "gameTypeId" INTEGER NOT NULL,
+    "winnerId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_Games" ("createdAt", "gameTypeId", "id", "order", "playerNum", "round", "statusId", "tournamentId", "updatedAt", "winnerId") SELECT "createdAt", "gameTypeId", "id", "order", "playerNum", "round", "statusId", "tournamentId", "updatedAt", "winnerId" FROM "Games";
+DROP TABLE "Games";
+ALTER TABLE "new_Games" RENAME TO "Games";
+CREATE TABLE "new_PlayerScores" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "statusId" INTEGER NOT NULL,
+    "gameId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_PlayerScores" ("createdAt", "gameId", "id", "score", "statusId", "updatedAt", "userId") SELECT "createdAt", "gameId", "id", "score", "statusId", "updatedAt", "userId" FROM "PlayerScores";
+DROP TABLE "PlayerScores";
+ALTER TABLE "new_PlayerScores" RENAME TO "PlayerScores";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WaitingRooms_name_key" ON "WaitingRooms"("name");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2,7 +2,7 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client"
+  provider = "prisma-client-js"
   output   = "../generated/prisma"
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,9 +17,7 @@ datasource db {
 
 /// 認証プロバイダーの種類
 enum AuthProvider {
-  google   // Google OAuth
   intra42  // 42 Intra OAuth
-  github   // GitHub OAuth
 }
 
 // ------------------------------------------------------
@@ -48,7 +46,7 @@ model Users {
   id                 Int          @id @default(autoincrement())
   
   email              String       @unique /// メールアドレス（システム内で一意）
-  name               String       /// 氏名（実名など）
+  name               String       /// 氏名（42のintra名など）
   nickname           String       /// 表示名
   pictureURL         String?      /// アバター画像のURL
   statusId           Int          /// アカウント状態（Statusesテーブルへの参照）
@@ -80,7 +78,8 @@ model Tournaments {
   id              Int               @id @default(autoincrement())
   
   statusId        Int               /// トーナメントの進行状況（Statusesテーブルへの参照）
-  
+  winnerId        Int?              /// 勝者のユーザーID（試合終了までNULL）
+
   createdAt       DateTime          @default(now())
   updatedAt       DateTime          @default(now()) @updatedAt
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,15 +12,6 @@ datasource db {
 }
 
 // ------------------------------------------------------
-// Enums (列挙型)
-// ------------------------------------------------------
-
-/// 認証プロバイダーの種類
-enum AuthProvider {
-  intra42  // 42 Intra OAuth
-}
-
-// ------------------------------------------------------
 // Models (テーブル定義)
 // ------------------------------------------------------
 
@@ -46,32 +37,15 @@ model Users {
   id                 Int          @id @default(autoincrement())
   
   email              String       @unique /// メールアドレス（システム内で一意）
-  name               String       /// 氏名（42のintra名など）
-  nickname           String       /// 表示名
-  pictureURL         String?      /// アバター画像のURL
+  name               String       /// 氏名（42のintra名が入る想定）
+  nickname           String       /// 表示名（後から変更可能）
+  pictureURL         String?      /// アバター画像のURL（後から変更可能）
   statusId           Int          /// アカウント状態（Statusesテーブルへの参照）
 
   createdAt          DateTime     @default(now())
   updatedAt          DateTime     @default(now()) @updatedAt
 }
 
-/// 外部認証プロバイダー（OAuth）のアカウント情報を管理するテーブル
-/// 1人のユーザーが複数の認証方法（Google, 42, GitHubなど）を持てるように設計
-model Accounts {
-  id                Int      @id @default(autoincrement())
-
-  statusId          Int          /// アカウント連携のステータス（Statusesテーブルへの参照）
-  userId            Int          /// 紐付くユーザーのID (Users.id)
-  
-  provider          AuthProvider /// 認証プロバイダーの種類
-  providerAccountId String       /// プロバイダー側でのユーザーID (sub, id等)
-
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
-
-  /// 同じプロバイダーで同じアカウントIDが重複しないように制約を設定
-  @@unique([provider, providerAccountId])
-}
 
 /// トーナメント情報を管理するテーブル
 model Tournaments {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,7 +20,6 @@ enum AuthProvider {
   google   // Google OAuth
   intra42  // 42 Intra OAuth
   github   // GitHub OAuth
-  local    // ローカル認証（Email/Password）
 }
 
 // ------------------------------------------------------
@@ -54,10 +53,6 @@ model Users {
   pictureURL         String?      /// アバター画像のURL
   statusId           Int          /// アカウント状態（Statusesテーブルへの参照）
 
-  // --- Two-factor authentication (2FA) ---
-  twoFactorSecret    String?      /// 2FA用のTOTP秘密鍵（Base32文字列）
-  isTwoFactorEnabled Boolean      @default(false) /// 2FA有効化フラグ
-  
   createdAt          DateTime     @default(now())
   updatedAt          DateTime     @default(now()) @updatedAt
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,7 +32,6 @@ model Statuses {
 }
 
 /// ユーザー情報を管理するテーブル
-/// 認証情報は Accounts テーブルに分離し、プロフィール情報のみを管理します
 model Users {
   id                 Int          @id @default(autoincrement())
   
@@ -63,7 +62,7 @@ model WaitingRooms {
   id              Int                 @id @default(autoincrement())
   
   statusId        Int                 /// 待機室のステータス（Statusesテーブルへの参照）
-  name            String              /// 部屋名
+  name            String              @unique /// 部屋名
   adminUserId     Int                 /// 部屋の管理者（作成者）
   
   createdAt       DateTime            @default(now())
@@ -91,9 +90,9 @@ model Games {
   
   statusId        Int               /// 試合の進行状況（Statusesテーブルへの参照）
   tournamentId    Int               /// 所属トーナメントID
-  round           Int               @default(1) /// 何回戦か (1: 1回戦, 2: 2回戦...)
-  order           Int               @default(1) /// そのラウンド内の何試合目か
-  playerNum       Int               @default(2) /// 参加人数（基本は2）
+  round           Int               /// 何回戦か (1: 1回戦, 2: 2回戦...)
+  order           Int               /// そのラウンド内の何試合目か
+  playerNum       Int               /// 参加人数（基本は2）
   gameTypeId      Int
   winnerId        Int?              /// 勝者のユーザーID（試合終了までNULL）
   
@@ -119,7 +118,7 @@ model PlayerScores {
   statusId        Int               /// スコアのステータス（Statusesテーブルへの参照）
   gameId          Int               /// 対象の試合ID
   userId          Int               /// プレイヤーのユーザーID
-  score           Int               @default(0) /// 獲得スコア
+  score           Int               /// 獲得スコア
   
   createdAt       DateTime          @default(now())
   updatedAt       DateTime          @default(now()) @updatedAt


### PR DESCRIPTION
# 概要
ログインを認証プロバイダのみに統一しました

# 実装内容
2FAとローカル認証の削除を行いました

# 動作確認
なし

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major Prisma/DB updates focused on simplifying auth and tightening schema.
> 
> - Remove `AuthProvider` enum, `Accounts` model, and 2FA fields from `Users`; switch generator to `prisma-client-js`
> - Drop `AppStatus`; introduce core tables: `Statuses`, `Users`, `Tournaments` (with optional `winnerId`), `WaitingRooms`, `WaitingRoomParticipants`, `Games`, `GameTypes`, `PlayerScores`
> - Add unique constraint on `WaitingRooms.name`
> - Remove defaults for `Games.round`, `Games.order`, `Games.playerNum`, and `PlayerScores.score` to require explicit values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30b12877c87c0a27e5df536fd36b120b51bc8523. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->